### PR TITLE
Batch opensea call.

### DIFF
--- a/src/utils/opensea.ts
+++ b/src/utils/opensea.ts
@@ -7,7 +7,7 @@ const chainToDomain = new Map<number, string>([
     [4, "rinkeby-api.opensea.io"],
 ]);
 
-const BATCH_SIZE = 20;
+const BATCH_SIZE = 30;
 
 function getDomain(): string {
     const chainId = LoginService.getInstance().chainId;

--- a/src/utils/opensea.ts
+++ b/src/utils/opensea.ts
@@ -7,6 +7,8 @@ const chainToDomain = new Map<number, string>([
     [4, "rinkeby-api.opensea.io"],
 ]);
 
+const BATCH_SIZE = 20;
+
 function getDomain(): string {
     const chainId = LoginService.getInstance().chainId;
     const domain = chainId && chainToDomain.get(chainId);
@@ -25,7 +27,7 @@ async function getAssets(additionalParams: URLSearchParams): Promise<Array<NFTMe
     });
     url.searchParams.append("order_direction", "desc");
     url.searchParams.append("offset", "0");
-    url.searchParams.append("limit", "20");
+    url.searchParams.append("limit", BATCH_SIZE.toString());
 
     const options = { method: 'GET', headers: { Accept: 'application/json' } };
     const response = await fetch(url.toString(), options);
@@ -47,10 +49,25 @@ export function FetchOwnedNFTs(walletAddress: string): Promise<Array<NFTMetadata
 
 // Takes partial tokens (only need to set address and tokenID) and returns full NFT metadata.
 export async function FetchMetadata(tokens: Array<NFTMetadata>): Promise<Array<NFTMetadata>> {
+    let promises : Promise<NFTMetadata[]>[] = [];
+
     let params = new URLSearchParams();
+    let tokenCount = 0;
     for (const token of tokens) {
+        if (tokenCount === BATCH_SIZE) {
+            promises.push(getAssets(params));
+            params = new URLSearchParams();
+            tokenCount = 0;
+        }
         params.append("asset_contract_addresses", token.address);
         params.append("token_ids", token.tokenID.toString());
+        tokenCount++;
     }
-    return getAssets(new URLSearchParams(params));
+    if (tokenCount > 0) {
+        promises.push(getAssets(params));
+    }
+
+    return Promise.all(promises).then(results => {
+        return results.flat();
+    });
 }


### PR DESCRIPTION
Opensea doesn't allow querying more than 30 tokens at a time. Batching the getAsset call to 30.